### PR TITLE
Use Hydra in nixpkgs

### DIFF
--- a/hydra-master.nix
+++ b/hydra-master.nix
@@ -2,14 +2,9 @@
 
 { config, pkgs, ... }:
 
-let
-
-  hydraSrc = builtins.fetchTarball https://github.com/nixos/hydra/archive/master.tar.gz;
-
-in
 {
 
-  imports = [ ./hydra-common.nix "${hydraSrc}/hydra-module.nix" ];
+  imports = [ ./hydra-common.nix ];
 
   assertions = pkgs.lib.singleton {
     assertion = pkgs.system == "x86_64-linux";


### PR DESCRIPTION
I'm thinking we should backport this to 16.03. Then we can merge this.
