### PR TITLE
README: 15.09 -> 16.03, remove unneeded step

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ this subject available at https://www.youtube.com/watch?v=RXV0Y5Bn-QQ.
 This repository contains a complex'ish example configuration for the Nix-based
 continuous build system [Hydra](http://nixos.org/hydra/) that new users can use
 to get started. The file [`hydra-common.nix`](hydra-common.nix) defines basic
-properties of a VBox-based virtual machine running NixOS 15.09, which
+properties of a VBox-based virtual machine running NixOS 16.03, which
 [`hydra-master.nix`](hydra-master.nix) extends to configure a running Hydra
 server. [`hydra-slave.nix`](hydra-slave.nix), on the other hand, configures a
 simple build slave for the main server to delegate build jobs to. Finally,
@@ -20,10 +20,10 @@ To run these examples quickly with `nixops` on your local machine, you'll need
 - 8+ GB of memory,
 - [NixOS](http://nixos.org/) and [Nixops](http://nixos.org/nixops/) installed.
 
-Also, your `configuration.nix` file should define:
+Also, your `configuration.nix` file should include:
 
-~~~~~ nix
-virtualisation.virtualbox.host.enable = true;
+~~~~~
+  virtualisation.virtualbox.host.enable = true;
 ~~~~~
 
 If those pre-conditions are met, follow these steps:
@@ -35,40 +35,22 @@ If those pre-conditions are met, follow these steps:
     $ ssh-keygen -C "hydra@hydra.example.org" -N "" -f id_buildfarm
     ~~~~~
 
-2. Set up your shell environment to use the `nixos-15.09` release for all
+2. Set up your shell environment to use the `nixos-16.03` release for all
     further commands:
 
     ~~~~~ bash
-    $ NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-15.09.tar.gz"
+    $ NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs-channels/archive/nixos-16.03.tar.gz"
     $ export NIX_PATH
     ~~~~~
 
-3. Make sure that your system knows the contents of the binary cache for that
-    branch! If your system is subscribed to the `release-15.09` channel, then
-    everything is fine. If you're not -- i.e. because you're running on
-    `unstable` --, then you'll have to add a subscription by running (as
-    `root`) the command:
-
-    ~~~~~ bash
-    $ nix-channel --add https://nixos.org/channels/nixos-15.09 nixos-15.09
-    $ nix-channel --update
-    ~~~~~
-
-    Futhermore, expend your `$NIX_PATH` to include the channel
-    information:
-
-    ~~~~~ bash
-    $ NIX_PATH+=":/nix/var/nix/profiles/per-user/root/channels/nixos"
-    ~~~~~
-
-4. Start the server:
+3. Start the server:
 
     ~~~~~ bash
     $ nixops create -d hydra hydra-network.nix
     $ nixops deploy -d hydra
     ~~~~~
 
-5. Ensure that the main server knows the binary cache for `nixos-15.09`:
+4. Ensure that the main server knows the binary cache for `nixos-16.03`:
 
     ~~~~~ bash
     nixops ssh hydra -- nix-channel --update


### PR DESCRIPTION
I've removed nix highlighting in that oneliner since github parser fails to display it properly.

cc @peti 
